### PR TITLE
use graph from ETL for port calls

### DIFF
--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -23,13 +23,13 @@ We get the difference between the departure and arrival displacements to get the
 
 <div class="custom-embed port-calls-chart">
   <iframe
-    src="interactive/ais/port%20calls.html"
+    src="../interactive/ais/port%20calls.html"
     style="border: 0; width: 100%; height: 600px;"
     title="Port Calls Dashboard"
     allowfullscreen>
   </iframe>
   <noscript>
-    <p><a href="interactive/ais/port%20calls.html">View the dashboard</a></p>
+    <p><a href="../interactive/ais/port%20calls.html">View the dashboard</a></p>
   </noscript>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,7 +21,7 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
-<div class="flourish-embed flourish-chart"><iframe src="../interactive/ais/port calls.html" name="Pacific Islands Map" id="Pacific Islands Map"></iframe></div>
+<div id="content"><iframe src="../interactive/ais/port calls.html"></iframe></div>
 
 ## Trade Volume
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 100%;">
+          style="width: 100%; height: 800px;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,7 +21,7 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
-<div id="content">
+<div style="width: 100%; max-width: 800px; margin: 0 auto;">
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,7 +21,7 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
-<div id="content" style="max-width: 100%; position: relative; height: 0; overflow: hidden;"><iframe src="../interactive/ais/port calls.html" name="Pacific Islands Map" id="Pacific Islands Map" style="border: 0; position: absolute; top: 0; left: 0; width: 100%; height: 100%;" allowfullscreen=""></iframe></div>
+<div class="port-call-embed"><iframe src="../interactive/ais/port calls.html" name="Pacific Islands Map" id="Pacific Islands Map" style="border: 0; position: absolute; top: 0; left: 0; width: 100%; height: 100%;" allowfullscreen=""></iframe></div>
 
 
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 800px;">
+          style="width: 100%; height: 600px;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,15 +21,18 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
-<div style="position: relative; width: 100%; height: 600px; overflow: hidden;">
+<div class="custom-embed port-calls-chart">
   <iframe
-    src="../interactive/ais/port calls.html"
-    name="Pacific Islands Map"
-    id="Pacific Islands Map"
-    style="border: 0; width: 100%; height: 100%; position: absolute; top: 0; left: 0;"
+    src="interactive/ais/port%20calls.html"
+    style="border: 0; width: 100%; height: 600px;"
+    title="Port Calls Dashboard"
     allowfullscreen>
   </iframe>
+  <noscript>
+    <p><a href="interactive/ais/port%20calls.html">View the dashboard</a></p>
+  </noscript>
 </div>
+
 
 
 ## Trade Volume

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 800px;">
+          style="width: 100%; height: 100%;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,10 +21,16 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
-<div id="content" style="max-width: 100%; position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-  <iframe src="../interactive/ais/port calls.html" name="Pacific Islands Map" id="Pacific Islands Map" style="border: 0; position: absolute; top: 0; left: 0; width: 100%; height: 100%;" allowfullscreen="">
+<div style="position: relative; width: 100%; height: 600px; overflow: hidden;">
+  <iframe
+    src="../interactive/ais/port calls.html"
+    name="Pacific Islands Map"
+    id="Pacific Islands Map"
+    style="border: 0; width: 100%; height: 100%; position: absolute; top: 0; left: 0;"
+    allowfullscreen>
   </iframe>
 </div>
+
 
 ## Trade Volume
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 600px;">
+          style="width: 100%; height: 700px;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 100vh;">
+          style="width: 100%; height: 800px;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,9 +21,7 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
-<div class="port-call-embed"><iframe src="../interactive/ais/port calls.html" name="Pacific Islands Map" id="Pacific Islands Map" style="border: 0; position: absolute; top: 0; left: 0; width: 100%; height: 100%;" allowfullscreen=""></iframe></div>
-
-
+<div class="flourish-embed flourish-chart"><iframe src="../interactive/ais/port calls.html" name="Pacific Islands Map" id="Pacific Islands Map"></iframe></div>
 
 ## Trade Volume
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%;">
+          style="width: 100%; height: 100vh;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,17 +21,7 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
-<div class="custom-embed port-calls-chart">
-  <iframe
-    src="../interactive/ais/port%20calls.html"
-    style="border: 0; width: 100%; height: 600px;"
-    title="Port Calls Dashboard"
-    allowfullscreen>
-  </iframe>
-  <noscript>
-    <p><a href="../interactive/ais/port%20calls.html">View the dashboard</a></p>
-  </noscript>
-</div>
+<div id="content" style="max-width: 100%; position: relative; height: 0; overflow: hidden;"><iframe src="../interactive/ais/port calls.html" name="Pacific Islands Map" id="Pacific Islands Map" style="border: 0; position: absolute; top: 0; left: 0; width: 100%; height: 100%;" allowfullscreen=""></iframe></div>
 
 
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 600px; border: none; display: block;">
+          style="width: 100%; height: 100vh; border: none; display: block;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,7 +21,13 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
-<div id="content"><iframe src="../interactive/ais/port calls.html"></iframe></div>
+<div id="content">
+  <iframe src="../interactive/ais/port calls.html"
+          frameborder="0"
+          scrolling="no"
+          style="width: 100%; height: 600px; border: none; display: block;">
+  </iframe>
+</div>
 
 ## Trade Volume
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -26,8 +26,6 @@ We get the difference between the departure and arrival displacements to get the
   </iframe>
 </div>
 
-<div class="flourish-embed flourish-chart" data-src="visualisation/19836784?2274258"><script src="https://public.flourish.studio/resources/embed.js"></script><noscript><img src="https://public.flourish.studio/visualisation/19836784/thumbnail" width="100%" alt="chart visualization" /></noscript></div>
-
 ## Trade Volume
 
 <div class="flourish-embed flourish-chart" data-src="visualisation/19837444?2274258"><script src="https://public.flourish.studio/resources/embed.js"></script><noscript><img src="https://public.flourish.studio/visualisation/19837444/thumbnail" width="100%" alt="chart visualization" /></noscript></div>

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 700px;">
+          style="width: 100%; height: 750px;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -21,6 +21,11 @@ We get the difference between the departure and arrival displacements to get the
 
 ## Port Arrivals 
 
+<div id="content" style="max-width: 100%; position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe src="../interactive/ais/port calls.html" name="Pacific Islands Map" id="Pacific Islands Map" style="border: 0; position: absolute; top: 0; left: 0; width: 100%; height: 100%;" allowfullscreen="">
+  </iframe>
+</div>
+
 <div class="flourish-embed flourish-chart" data-src="visualisation/19836784?2274258"><script src="https://public.flourish.studio/resources/embed.js"></script><noscript><img src="https://public.flourish.studio/visualisation/19836784/thumbnail" width="100%" alt="chart visualization" /></noscript></div>
 
 ## Trade Volume

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 100vh; border: none; display: block;">
+          style="width: 100%;">
   </iframe>
 </div>
 

--- a/docs/ais/ais_trade.md
+++ b/docs/ais/ais_trade.md
@@ -25,7 +25,7 @@ We get the difference between the departure and arrival displacements to get the
   <iframe src="../interactive/ais/port calls.html"
           frameborder="0"
           scrolling="no"
-          style="width: 100%; height: 750px;">
+          style="width: 100%; height: 650px;">
   </iframe>
 </div>
 

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -7,13 +7,21 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
   <style>
-    body {
+    html, body {
+      height: 100%;
+      margin: 0;
+      padding: 0;
       font-family: 'Open Sans', sans-serif;
-      margin: 20px;
     }
     h2 {
       font-size: 24px;
       margin-bottom: 10px;
+    }
+    #chart {
+      width: 100%;
+      height: 600px; /* or use 100vh for full screen */
+      margin: 0;
+      padding: 0;
     }
     label, select {
       font-size: 16px;
@@ -149,6 +157,13 @@
       });
 
       const layout = {
+        autosize: true,
+        margin: {
+          l: 20,
+          r: 20,
+          t: 40,
+          b: 40
+        },
         title: {
           text: `<b>Monthly Port Arrivals - ${selectedPort === "__ALL__" ? "All Ports" : selectedPort}, ${selectedCountry === "__ALL__" ? "All Countries" : selectedCountry}</b>`,
           font: {

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -30,7 +30,7 @@
   <label for="portSelect">Port:</label>
   <select id="portSelect"></select>
 
-  <div id="chart" style="width:100%;max-width:1000px;height:600px;"></div>
+  <div id="chart" style="width:100%;height:100%;"></div>
 
   <script>
     const hlCategories = ["Cargo", "Fishing", "Passenger", "Tanker"];

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -61,6 +61,7 @@
     font-family: 'Open Sans', sans-serif;
   ">
    Counts, Monthly
+   </p>
 </div>
 
   <label for="countrySelect">Country:</label>

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -9,12 +9,12 @@
   <style>
     html, body {
       height: 100%;
-      margin: 0;
-      padding: 0;
+      margin: ;
+      padding: 5px;
       font-family: 'Open Sans', sans-serif;
     }
     h2 {
-      font-size: 24px;
+      font-size: 20px;
       margin-bottom: 10px;
     }
     #chart {
@@ -24,8 +24,9 @@
       padding: 0;
     }
     label, select {
-      font-size: 16px;
+      font-size: 14px;
       margin-right: 10px;
+      font-family: 'Open Sans', sans-serif;
     }
   </style>
 </head>
@@ -159,10 +160,10 @@
       const layout = {
         autosize: true,
         margin: {
-          l: 20,
+          l: 40,
           r: 20,
-          t: 40,
-          b: 40
+          t: 80,
+          b: 80
         },
         title: {
           text: `<b>Monthly Port Arrivals - ${selectedPort === "__ALL__" ? "All Ports" : selectedPort}, ${selectedCountry === "__ALL__" ? "All Countries" : selectedCountry}</b>`,
@@ -171,16 +172,69 @@
             size: 20
           }
         },
+        yaxis: {
+          showline:true,
+          linecolor: '#ccc',
+          griddash: 'dot',
+          gridcolor: '#ccc',
+          ticks: 'outside',
+          tickcolor: '#ccc',
+          zeroline: false
+        },
         xaxis: {
-          rangeslider: { visible: true },
-          title: ''
+          rangeslider: { visible: true},
+          title: '',
+          showgrid: false,
+          ticks: 'outside',
+          tickson: 'boundaries',
+          tickcolor:'#ccc',
+          showline: true,
+          linecolor : '#ccc'
         },
         legend: {
-    orientation: 'h',
-    x: 0,
-    y: 1
-  }
-
+          orientation: 'h',
+          x: 0,
+          y: 1,
+        },
+        hoverlabel:{
+          font:{family: 'Open Sans, sans-serif'}
+        },
+         images: [
+          {
+            source: 'https://public.flourish.studio/uploads/71a85b0c-7f8c-453b-bc80-22b945333d58.png',
+            xref: 'paper',
+            yref: 'paper',
+            x: 1,
+            y:-0.34,
+            xanchor: 'right',
+            yanchor: 'bottom',
+            sizex: 0.20,         // adjust size as needed
+            sizey: 0.15,
+            xshift: -10,         // optional: nudge inward
+            yshift: 10,
+            opacity: 1,
+            layer: 'above'
+          }
+        ],
+          annotations: [
+        {
+          text: 'Source: <a href="https://worldbank.org/" target="_blank" style="color:#888;text-decoration:underline;">World Bank Group</a>',
+          xref: 'paper',
+          yref: 'paper',
+          x: -0.05,
+          y: -0.34,                // 👈 places it below the chart and slider
+          xanchor: 'left',
+          yanchor: 'bottom',
+          showarrow: false,
+          font: {
+            size: 12,
+            color: '#888',
+            family: 'Open Sans, sans-serif'
+          },
+          xshift: 10,
+          yshift: 0
+        }
+  ],
       };
 
       Plotly.newPlot('chart', traces, layout, {responsive: true});

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -44,9 +44,6 @@
 <body>
 
 <div id="titleRow" style="
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
   margin-bottom: 10px;
 ">
   <h2 id="chartTitle" style="
@@ -55,8 +52,15 @@
     margin: 0;
     font-family: 'Open Sans', sans-serif;
   ">
-    Monthly Port Arrivals
+    Port Arrivals Derived from AIS
   </h2>
+  <p id="chartSubtitle" style="
+    font-size: 16px;
+    color: #666;
+    margin: 4px 0 0;
+    font-family: 'Open Sans', sans-serif;
+  ">
+   Counts, Monthly
 </div>
 
   <label for="countrySelect">Country:</label>
@@ -73,7 +77,7 @@
   align-items: center;
   padding: 10px 20px;
   font-family: 'Open Sans', sans-serif;
-  font-size: 14px;
+  font-size: 12px;
   color: #888;
   ">
     <div>

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -9,7 +9,7 @@
   <style>
     html, body {
       height: 100%;
-      margin: ;
+      margin-bottom: 5px;
       padding: 5px;
       font-family: 'Open Sans', sans-serif;
     }
@@ -39,7 +39,8 @@
   <label for="portSelect">Port:</label>
   <select id="portSelect"></select>
 
-  <div id="chart" style="width:100%;height:100%;"></div>
+  <div id="chart" style="width:100%;height:100%;position:relative;"></div>
+  
 
   <script>
     const hlCategories = ["Cargo", "Fishing", "Passenger", "Tanker"];
@@ -163,7 +164,7 @@
           l: 40,
           r: 20,
           t: 80,
-          b: 80
+          b: 50
         },
         title: {
           text: `<b>Monthly Port Arrivals - ${selectedPort === "__ALL__" ? "All Ports" : selectedPort}, ${selectedCountry === "__ALL__" ? "All Countries" : selectedCountry}</b>`,
@@ -199,45 +200,46 @@
         hoverlabel:{
           font:{family: 'Open Sans, sans-serif'}
         },
-         images: [
-          {
-            source: 'https://public.flourish.studio/uploads/71a85b0c-7f8c-453b-bc80-22b945333d58.png',
-            xref: 'paper',
-            yref: 'paper',
-            x: 1,
-            y:-0.34,
-            xanchor: 'right',
-            yanchor: 'bottom',
-            sizex: 0.20,         // adjust size as needed
-            sizey: 0.15,
-            xshift: -10,         // optional: nudge inward
-            yshift: 10,
-            opacity: 1,
-            layer: 'above'
-          }
-        ],
-          annotations: [
-        {
-          text: 'Source: <a href="https://worldbank.org/" target="_blank" style="color:#888;text-decoration:underline;">World Bank Group</a>',
-          xref: 'paper',
-          yref: 'paper',
-          x: -0.05,
-          y: -0.34,                // 👈 places it below the chart and slider
-          xanchor: 'left',
-          yanchor: 'bottom',
-          showarrow: false,
-          font: {
-            size: 12,
-            color: '#888',
-            family: 'Open Sans, sans-serif'
-          },
-          xshift: 10,
-          yshift: 0
-        }
-  ],
       };
 
       Plotly.newPlot('chart', traces, layout, {responsive: true});
+
+      const chartDiv = document.getElementById('chart');
+
+// Create footer container
+const footer = document.createElement('div');
+footer.style.position = 'absolute';
+footer.style.bottom = '0px';
+footer.style.left = '0';
+footer.style.width = '100%';
+footer.style.display = 'flex';
+footer.style.justifyContent = 'space-between';
+footer.style.alignItems = 'center';
+footer.style.padding = '10px 20px';
+footer.style.fontFamily = 'Open Sans, sans-serif';
+footer.style.fontSize = '14px';
+footer.style.color = '#888';
+
+// Add link
+const link = document.createElement('div');
+link.innerHTML = 'Source: <a href="https://www.worldbank.org" target="_blank" style="text-decoration: underline; color: #888;">World Bank Group</a>';
+link.style.color = '#888';
+link.style.fontFamily = 'Open Sans, sans-serif';
+link.style.fontSize = '12px';
+
+
+// Add logo
+const logo = document.createElement('img');
+logo.src = 'https://public.flourish.studio/uploads/71a85b0c-7f8c-453b-bc80-22b945333d58.png';
+logo.style.height = '30px';
+logo.style.objectFit = 'contain';
+logo.style.marginRight = '5px';
+
+// Append to footer
+footer.appendChild(link);
+footer.appendChild(logo);
+chartDiv.appendChild(footer);
+
     }
   </script>
 </body>

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -12,6 +12,7 @@
       margin-bottom: 5px;
       padding: 2px;
       font-family: 'Open Sans', sans-serif;
+      background-color: white;
     }
     h2 {
       font-size: 20px;

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -40,6 +40,22 @@
   <select id="portSelect"></select>
 
   <div id="chart" style="width:100%;height:100%;position:relative;"></div>
+  <div id="footer" style="
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 14px;
+  color: #888;
+  ">
+    <div>
+      Source: <a href="https://www.worldbank.org" target="_blank" style="text-decoration: underline; color: #888;">World Bank Group</a>
+    </div>
+    <img src="https://public.flourish.studio/uploads/71a85b0c-7f8c-453b-bc80-22b945333d58.png" style="height: 30px; object-fit: contain; margin-right: 5px;" alt="Logo">
+  </div>
+
   
 
   <script>
@@ -205,40 +221,6 @@
       Plotly.newPlot('chart', traces, layout, {responsive: true});
 
       const chartDiv = document.getElementById('chart');
-
-// Create footer container
-const footer = document.createElement('div');
-footer.style.position = 'absolute';
-footer.style.bottom = '0px';
-footer.style.left = '0';
-footer.style.width = '100%';
-footer.style.display = 'flex';
-footer.style.justifyContent = 'space-between';
-footer.style.alignItems = 'center';
-footer.style.padding = '10px 20px';
-footer.style.fontFamily = 'Open Sans, sans-serif';
-footer.style.fontSize = '14px';
-footer.style.color = '#888';
-
-// Add link
-const link = document.createElement('div');
-link.innerHTML = 'Source: <a href="https://www.worldbank.org" target="_blank" style="text-decoration: underline; color: #888;">World Bank Group</a>';
-link.style.color = '#888';
-link.style.fontFamily = 'Open Sans, sans-serif';
-link.style.fontSize = '12px';
-
-
-// Add logo
-const logo = document.createElement('img');
-logo.src = 'https://public.flourish.studio/uploads/71a85b0c-7f8c-453b-bc80-22b945333d58.png';
-logo.style.height = '30px';
-logo.style.objectFit = 'contain';
-logo.style.marginRight = '5px';
-
-// Append to footer
-footer.appendChild(link);
-footer.appendChild(logo);
-chartDiv.appendChild(footer);
 
     }
   </script>

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -28,10 +28,37 @@
       margin-right: 10px;
       font-family: 'Open Sans', sans-serif;
     }
+    select {
+      border: none;
+      border-bottom: 1px solid #888;
+      background-color: transparent;
+      font-size: 14px;
+      padding: 5px 0;
+      outline: none;
+      font-family: 'Open Sans', sans-serif;
+      color: #333;
+      cursor: pointer;
+    }
+
   </style>
 </head>
 <body>
 
+<div id="titleRow" style="
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 10px;
+">
+  <h2 id="chartTitle" style="
+    font-size: 20px;
+    font-weight: bold;
+    margin: 0;
+    font-family: 'Open Sans', sans-serif;
+  ">
+    Monthly Port Arrivals
+  </h2>
+</div>
 
   <label for="countrySelect">Country:</label>
   <select id="countrySelect"></select>
@@ -181,13 +208,6 @@
           r: 20,
           t: 80,
           b: 50
-        },
-        title: {
-          text: `<b>Monthly Port Arrivals - ${selectedPort === "__ALL__" ? "All Ports" : selectedPort}, ${selectedCountry === "__ALL__" ? "All Countries" : selectedCountry}</b>`,
-          font: {
-            family: 'Open Sans, sans-serif',
-            size: 20
-          }
         },
         yaxis: {
           showline:true,

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -70,7 +70,7 @@
   <label for="portSelect">Port:</label>
   <select id="portSelect"></select>
 
-  <div id="chart" style="width:100%;height:100%;position:relative;"></div>
+  <div id="chart" style="width:100%;position:relative;"></div>
   <div id="footer" style="
   width: 100%;
   display: flex;

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -39,7 +39,6 @@
       color: #333;
       cursor: pointer;
     }
-
   </style>
 </head>
 <body>

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -10,7 +10,7 @@
     html, body {
       height: 100%;
       margin-bottom: 5px;
-      padding: 5px;
+      padding: 2px;
       font-family: 'Open Sans', sans-serif;
     }
     h2 {
@@ -76,15 +76,14 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 20px;
   font-family: 'Open Sans', sans-serif;
   font-size: 12px;
   color: #888;
   ">
-    <div>
+    <div style="margin-bottom:10px;">
       Source: <a href="https://www.worldbank.org" target="_blank" style="text-decoration: underline; color: #888;">World Bank Group</a>
     </div>
-    <img src="https://public.flourish.studio/uploads/71a85b0c-7f8c-453b-bc80-22b945333d58.png" style="height: 30px; object-fit: contain; margin-right: 5px;" alt="Logo">
+    <img src="https://public.flourish.studio/uploads/71a85b0c-7f8c-453b-bc80-22b945333d58.png" style="height: 25px; object-fit: contain; margin-right: 5px; margin-bottom:10px;" alt="Logo">
   </div>
 
   
@@ -210,8 +209,8 @@
         margin: {
           l: 40,
           r: 20,
-          t: 80,
-          b: 50
+          t: 10,
+          b: 0
         },
         yaxis: {
           showline:true,

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -168,7 +168,7 @@
 
       };
 
-      Plotly.newPlot('chart', traces, layout);
+      Plotly.newPlot('chart', traces, layout, {responsive: true});
     }
   </script>
 </body>

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -19,7 +19,7 @@
     }
     #chart {
       width: 100%;
-      height: 600px; /* or use 100vh for full screen */
+      height: 500px; /* or use 100vh for full screen */
       margin: 0;
       padding: 0;
     }

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Port Arrivals</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
+  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
+  <style>
+    body {
+      font-family: 'Open Sans', sans-serif;
+      margin: 20px;
+    }
+    h2 {
+      font-size: 24px;
+      margin-bottom: 10px;
+    }
+    label, select {
+      font-size: 16px;
+      margin-right: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h2>Port Arrivals</h2>
+
+  <label for="countrySelect">Country:</label>
+  <select id="countrySelect"></select>
+
+  <label for="portSelect">Port:</label>
+  <select id="portSelect"></select>
+
+  <div id="chart" style="width:100%;max-width:1000px;height:600px;"></div>
+
+  <script>
+    const hlCategories = ["Cargo", "Fishing", "Passenger", "Tanker"];
+    let fullData = [];
+
+    Papa.parse("https://raw.githubusercontent.com/cherrylchico/pacific-observatory-ais-data/main/data/monthly%20port%20calls.csv", {
+      download: true,
+      header: true,
+      skipEmptyLines: true,
+      complete: function(results) {
+        fullData = results.data.filter(d =>
+          hlCategories.includes(d.HL) &&
+          d["port call"] &&
+          !isNaN(parseInt(d["port call"]))
+        );
+        populateCountryDropdown();
+      }
+    });
+
+    function populateCountryDropdown() {
+      const countries = [...new Set(fullData.map(d => d.Country))].sort();
+      const countrySelect = document.getElementById("countrySelect");
+      countrySelect.innerHTML = "";
+
+      const allOption = document.createElement("option");
+      allOption.value = "__ALL__";
+      allOption.textContent = "All Countries";
+      countrySelect.appendChild(allOption);
+
+      countries.forEach(c => {
+        const option = document.createElement("option");
+        option.value = c;
+        option.textContent = c;
+        countrySelect.appendChild(option);
+      });
+
+      countrySelect.addEventListener("change", populatePortDropdown);
+      countrySelect.value = "__ALL__";
+      populatePortDropdown();
+    }
+
+    function populatePortDropdown() {
+      const selectedCountry = document.getElementById("countrySelect").value;
+      const portSelect = document.getElementById("portSelect");
+
+      portSelect.innerHTML = "";
+
+      const allOption = document.createElement("option");
+      allOption.value = "__ALL__";
+      allOption.textContent = "All Ports";
+      portSelect.appendChild(allOption);
+
+      if (selectedCountry === "__ALL__") {
+        portSelect.disabled = true;
+      } else {
+        const ports = [...new Set(fullData.filter(d => d.Country === selectedCountry).map(d => d.Port))].sort();
+        ports.forEach(p => {
+          const option = document.createElement("option");
+          option.value = p;
+          option.textContent = p;
+          portSelect.appendChild(option);
+        });
+        portSelect.disabled = false;
+      }
+
+      portSelect.addEventListener("change", updateChart);
+      portSelect.value = "__ALL__";
+      updateChart();
+    }
+
+    function updateChart() {
+      const selectedCountry = document.getElementById("countrySelect").value;
+      const selectedPort = document.getElementById("portSelect").value;
+
+      let filtered = fullData.filter(d => hlCategories.includes(d.HL));
+
+      if (selectedCountry !== "__ALL__") {
+        filtered = filtered.filter(d => d.Country === selectedCountry);
+        if (selectedPort !== "__ALL__") {
+          filtered = filtered.filter(d => d.Port === selectedPort);
+        }
+      }
+
+      const yearList = [...new Set(filtered.map(d => d.year))].sort();
+      const allMonths = [];
+      yearList.forEach(year => {
+        for (let m = 1; m <= 12; m++) {
+          allMonths.push({ year: year, month: m });
+        }
+      });
+
+      const traces = hlCategories.map(hl => {
+        const x = [];
+        const y = [];
+
+        allMonths.forEach(({ year, month }) => {
+          const entries = filtered.filter(d =>
+            d.year == year &&
+            parseInt(d.month) == month &&
+            d.HL === hl
+          );
+          const total = entries.reduce((sum, d) => sum + parseInt(d["port call"]), 0);
+          if (total > 0) {
+            x.push(`${year}-${month}`);
+            y.push(total);
+          }
+        });
+
+        return {
+          x: x,
+          y: y,
+          name: hl,
+          type: 'scatter',
+          mode: 'lines'
+        };
+      });
+
+      const layout = {
+        title: {
+          text: `Monthly Port Arrivals - ${selectedPort === "__ALL__" ? "All Ports" : selectedPort}, ${selectedCountry === "__ALL__" ? "All Countries" : selectedCountry}`,
+          font: {
+            family: 'Open Sans, sans-serif',
+            size: 20
+          }
+        },
+        xaxis: {
+          rangeslider: { visible: true },
+          title: ''
+        },
+        yaxis: {
+          title: 'Number of Arrivals'
+        },
+          legend: {
+    orientation: 'h',
+    x: 0,
+    y: 1
+  }
+
+      };
+
+      Plotly.newPlot('chart', traces, layout);
+    }
+  </script>
+</body>
+</html>

--- a/docs/images/interactive/ais/port calls.html
+++ b/docs/images/interactive/ais/port calls.html
@@ -22,7 +22,7 @@
   </style>
 </head>
 <body>
-  <h2>Port Arrivals</h2>
+
 
   <label for="countrySelect">Country:</label>
   <select id="countrySelect"></select>
@@ -150,7 +150,7 @@
 
       const layout = {
         title: {
-          text: `Monthly Port Arrivals - ${selectedPort === "__ALL__" ? "All Ports" : selectedPort}, ${selectedCountry === "__ALL__" ? "All Countries" : selectedCountry}`,
+          text: `<b>Monthly Port Arrivals - ${selectedPort === "__ALL__" ? "All Ports" : selectedPort}, ${selectedCountry === "__ALL__" ? "All Countries" : selectedCountry}</b>`,
           font: {
             family: 'Open Sans, sans-serif',
             size: 20
@@ -160,10 +160,7 @@
           rangeslider: { visible: true },
           title: ''
         },
-        yaxis: {
-          title: 'Number of Arrivals'
-        },
-          legend: {
+        legend: {
     orientation: 'h',
     x: 0,
     y: 1


### PR DESCRIPTION
As part of the automation of Pacific AIS outputs, we have created an ETL to produce the indicators monthly on a regular basis. Currently the ETL and data output repositories are in Cherryl's account. This needs to be transferred to the WB group github account. 

In this commit, the references to the Port Call graph has been changed to an HTML that uses the data from the output. This ensures that every time the output is updated, the corresponding graph is also updated. 